### PR TITLE
Add ability to include multiple non-image parts in outgoing MMS

### DIFF
--- a/library/src/main/java/com/klinker/android/send_message/Message.java
+++ b/library/src/main/java/com/klinker/android/send_message/Message.java
@@ -292,14 +292,24 @@ public class Message {
         this.images = new Bitmap[1];
         this.images[0] = image;
     }
-    
+
+    /**
+     * Sets audio file.  Must be in wav format.
+     *
+     * @param audio is the single audio sample to send to recipient
+     */
+    @Deprecated
+    public void setAudio(byte[] audio) {
+        addAudio(audio);
+    }
+
     /**
      * Sets audio file.  Must be in wav format.
      *
      * @param audio is the single audio sample to send to recipient
      */
     public void addAudio(byte[] audio) {
-        this.parts.add(new Part(audio, "audio/wav", null));
+        addMedia(audio, "audio/wav");
     }
 
     /**
@@ -307,12 +317,33 @@ public class Message {
      *
      * @param video is the single video sample to send to recipient
      */
+    @Deprecated
+    public void setVideo(byte[] video) {
+        addVideo(video);
+    }
+
+    /**
+     * Adds video file
+     *
+     * @param video is the single video sample to send to recipient
+     */
     public void addVideo(byte[] video) {
-        this.parts.add(new Part(video, "video/3gpp", null));
+        addMedia(video, "video/3gpp");
     }
 
     /**
      * Sets other media
+     *
+     * @param media is the media you want to send
+     * @param mimeType is the mimeType of the media
+     */
+    @Deprecated
+    public void setMedia(byte[] media, String mimeType) {
+         addMedia(media, mimeType);
+    }
+
+    /**
+     * Adds other media
      *
      * @param media is the media you want to send
      * @param mimeType is the mimeType of the media

--- a/library/src/main/java/com/klinker/android/send_message/Message.java
+++ b/library/src/main/java/com/klinker/android/send_message/Message.java
@@ -20,6 +20,8 @@ import android.graphics.Bitmap;
 import com.klinker.android.logger.Log;
 
 import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Class to hold all relevant message information to send
@@ -28,13 +30,34 @@ import java.io.ByteArrayOutputStream;
  */
 public class Message {
 
+    public static final class Part {
+        private byte[] media;
+        private String contentType;
+        private String name;
+        public Part(byte[] media, String contentType, String name) {
+            this.media = media;
+            this.contentType = contentType;
+            this.name = name;
+        }
+
+        public byte[] getMedia() {
+            return media;
+        }
+
+        public String getContentType() {
+            return contentType;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
     private String text;
     private String subject;
     private String[] addresses;
     private Bitmap[] images;
     private String[] imageNames;
-    private byte[] media;
-    private String mediaMimeType;
+    private List<Part> parts = new ArrayList<Part>();
     private boolean save;
     private int type;
     private int delay;
@@ -88,8 +111,6 @@ public class Message {
         this.addresses = addresses;
         this.images = new Bitmap[0];
         this.subject = null;
-        this.media = new byte[0];
-        this.mediaMimeType = null;
         this.save = true;
         this.type = TYPE_SMSMMS;
         this.delay = 0;
@@ -107,8 +128,6 @@ public class Message {
         this.addresses = addresses;
         this.images = new Bitmap[0];
         this.subject = subject;
-        this.media = new byte[0];
-        this.mediaMimeType = null;
         this.save = true;
         this.type = TYPE_SMSMMS;
         this.delay = 0;
@@ -195,8 +214,6 @@ public class Message {
         this.addresses = addresses;
         this.images = images;
         this.subject = null;
-        this.media = new byte[0];
-        this.mediaMimeType = null;
         this.save = true;
         this.type = TYPE_SMSMMS;
         this.delay = 0;
@@ -215,8 +232,6 @@ public class Message {
         this.addresses = addresses;
         this.images = images;
         this.subject = subject;
-        this.media = new byte[0];
-        this.mediaMimeType = null;
         this.save = true;
         this.type = TYPE_SMSMMS;
         this.delay = 0;
@@ -279,13 +294,12 @@ public class Message {
     }
     
     /**
-     * Sets audio file
+     * Sets audio file.  Must be in wav format.
      *
      * @param audio is the single audio sample to send to recipient
      */
-    public void setAudio(byte[] audio) {
-        this.media = audio;
-        this.mediaMimeType = "audio/wav";
+    public void addAudio(byte[] audio) {
+        this.parts.add(new Part(audio, "audio/wav", null));
     }
 
     /**
@@ -293,9 +307,8 @@ public class Message {
      *
      * @param video is the single video sample to send to recipient
      */
-    public void setVideo(byte[] video) {
-        this.media = video;
-        this.mediaMimeType = "video/3gpp";
+    public void addVideo(byte[] video) {
+        this.parts.add(new Part(video, "video/3gpp", null));
     }
 
     /**
@@ -304,9 +317,8 @@ public class Message {
      * @param media is the media you want to send
      * @param mimeType is the mimeType of the media
      */
-    public void setMedia(byte[] media, String mimeType) {
-        this.media = media;
-        this.mediaMimeType = mimeType;
+    public void addMedia(byte[] media, String mimeType) {
+        this.parts.add(new Part(media, mimeType, null));
     }
 
     /**
@@ -430,17 +442,8 @@ public class Message {
      *
      * @return an array of bytes with audio information for the message
      */
-    public byte[] getMedia() {
-        return this.media;
-    }
-
-    /**
-     * Gets the mimetype of the extra media (eg, audio or video)
-     *
-     * @return a string of the mimetype
-     */
-    public String getMediaMimeType() {
-        return this.mediaMimeType;
+    public List<Part> getParts() {
+        return this.parts;
     }
 
     /**


### PR DESCRIPTION
I needed the ability to send multiple non-image attachments in MMS (right now the vCard but I expect video to be coming very soon).  To solve that, I changed Message from holding a single media and mediaMimeType to Message holds a List of Part (new class that contains the bytes and mime type).  Transaction was updated to use the list when checking for MMS and when sending the MMS.

There is an API breaking change of renaming setImage/setVideo/setMedia to addImage/addVideo/addMedia.  I can add them back, but was unsure of what they should do.  Some thoughts:
1. Clear out the existing list (if any) and add their argument to the list as the sole part
2. Clear out the existing list (if any) and add their argument to the list as the sole part and set a flag of some sort to not allow the add methods to be called without error in the future
3. If there's anything already in the list throw exception not allowing previously set to be wiped out.  If nothing is in the list then add the argument as the sole member to the list
4. Call add with the arguments and allow previously set parts be retained

I also thought about refactoring addImage to put the image into the part list and do the image conversion at the time of addition instead of sending, but didn't follow through on that to make the change smaller.

If you are interested in incorporating this change let me know how you want the set methods to behave and I'll get that working and submit again.

Randy
