### PR TITLE
Transaction: check text for null before blank

### DIFF
--- a/library/src/main/java/com/klinker/android/send_message/Transaction.java
+++ b/library/src/main/java/com/klinker/android/send_message/Transaction.java
@@ -352,7 +352,7 @@ public class Transaction {
             }
         }
 
-        if (!text.equals("")) {
+        if (text != null && !text.equals("")) {
             // add text to the end of the part and send
             MMSPart part = new MMSPart();
             part.Name = "text";


### PR DESCRIPTION
This allows sending a message with no text at all instead of a text value of "".