### PR TITLE
Allow sending of MMS as non-default app

### DIFF
--- a/library/src/main/java/com/klinker/android/send_message/MmsSentReceiver.java
+++ b/library/src/main/java/com/klinker/android/send_message/MmsSentReceiver.java
@@ -22,6 +22,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.provider.Telephony;
+import android.text.TextUtils;
 
 import com.google.android.mms.util_alt.SqliteWrapper;
 import com.klinker.android.logger.Log;
@@ -40,17 +41,22 @@ public class MmsSentReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         Log.v(TAG, "MMS has finished sending, marking it as so in the database");
 
-        Uri uri = Uri.parse(intent.getStringExtra(EXTRA_CONTENT_URI));
-        Log.v(TAG, uri.toString());
+        String extraContentUri = intent.getStringExtra(EXTRA_CONTENT_URI);
+        if (!TextUtils.isEmpty(extraContentUri)) {
+            Uri uri = Uri.parse(extraContentUri);
+            Log.v(TAG, uri.toString());
 
-        ContentValues values = new ContentValues(1);
-        values.put(Telephony.Mms.MESSAGE_BOX, Telephony.Mms.MESSAGE_BOX_SENT);
-        SqliteWrapper.update(context, context.getContentResolver(), uri, values,
-                null, null);
+            ContentValues values = new ContentValues(1);
+            values.put(Telephony.Mms.MESSAGE_BOX, Telephony.Mms.MESSAGE_BOX_SENT);
+            SqliteWrapper.update(context, context.getContentResolver(), uri, values,
+                    null, null);
+        }
 
         String filePath = intent.getStringExtra(EXTRA_FILE_PATH);
-        Log.v(TAG, filePath);
-        new File(filePath).delete();
+        if (!TextUtils.isEmpty(filePath)) {
+            Log.v(TAG, filePath);
+            new File(filePath).delete();
+        }
     }
 
 }

--- a/library/src/main/java/com/klinker/android/send_message/Transaction.java
+++ b/library/src/main/java/com/klinker/android/send_message/Transaction.java
@@ -615,9 +615,6 @@ public class Transaction {
             File mSendFile = new File(context.getCacheDir(), fileName);
 
             SendReq sendReq = buildPdu(context, addresses, subject, parts);
-            PduPersister persister = PduPersister.getPduPersister(context);
-            Uri messageUri = persister.persist(sendReq, Uri.parse("content://mms/outbox"),
-                    true, settings.getGroup(), null);
 
             Intent intent;
             if (explicitSentMmsReceiver == null) {
@@ -627,7 +624,13 @@ public class Transaction {
                 intent = explicitSentMmsReceiver;
             }
 
-            intent.putExtra(MmsSentReceiver.EXTRA_CONTENT_URI, messageUri.toString());
+            if (Utils.isDefaultSmsApp(context)) {
+                PduPersister persister = PduPersister.getPduPersister(context);
+                Uri messageUri = persister.persist(sendReq, Uri.parse("content://mms/outbox"),
+                        true, settings.getGroup(), null);
+                intent.putExtra(MmsSentReceiver.EXTRA_CONTENT_URI, messageUri.toString());
+            }
+
             intent.putExtra(MmsSentReceiver.EXTRA_FILE_PATH, mSendFile.getPath());
             final PendingIntent pendingIntent = PendingIntent.getBroadcast(
                     context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);


### PR DESCRIPTION
Using information from #56 (thank you baracudda!) I've added the ability to send MMS messages without being the default app. This commit does not change the minSdkVersion, so it should still work for users below lollipop. I have only tested this with an Android O device, however the changes are very small and shouldn't effect much.

BTW, I have tested sending MMS as the default app, and setting useSystemSetting before making these changes. This does not work, however, because the library crashes when trying to open a uri to the mms database. Write access to this db has been locked for non-default apps for more recent android versions.