### PR TITLE
Change 'compile' to 'implementation' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ For full details on how to implement, please check out the sample application. I
 To include in your gradle project:
 
 ```groovy
-compile 'com.klinkerapps:android-smsmms:5.1.0'
+implementation 'com.klinkerapps:android-smsmms:5.1.0'
 ```
 
 ---


### PR DESCRIPTION
`compile` has been deprecated in favor of `implementation` and `api`, per [here](https://developer.android.com/studio/build/dependencies?utm_source=android-studio#dependency_configurations)