### PR TITLE
Save the original sent time for received MMS messages

### DIFF
--- a/library/src/main/java/com/android/mms/service_alt/DownloadRequest.java
+++ b/library/src/main/java/com/android/mms/service_alt/DownloadRequest.java
@@ -187,6 +187,7 @@ public class DownloadRequest extends MmsRequest {
             // Update some of the properties of the message
             final ContentValues values = new ContentValues();
             values.put(Telephony.Mms.DATE, System.currentTimeMillis() / 1000L);
+            values.put(Telephony.Mms.DATE_SENT, retrieveConf.getDate());
             values.put(Telephony.Mms.READ, 0);
             values.put(Telephony.Mms.SEEN, 0);
             if (!TextUtils.isEmpty(creator)) {

--- a/library/src/main/java/com/android/mms/service_alt/MmsRequestManager.java
+++ b/library/src/main/java/com/android/mms/service_alt/MmsRequestManager.java
@@ -89,8 +89,10 @@ public class MmsRequestManager implements MmsRequest.RequestManager {
                     group, null);
 
             // Use local time instead of PDU time
-            ContentValues values = new ContentValues(2);
+            ContentValues values = new ContentValues(3);
             values.put(Telephony.Mms.DATE, System.currentTimeMillis() / 1000L);
+            // Store PDU time as sent time for received message
+            values.put(Telephony.Mms.DATE_SENT, retrieveConf.getDate());
             values.put(Telephony.Mms.MESSAGE_SIZE, response.length);
             SqliteWrapper.update(context, context.getContentResolver(),
                     msgUri, values, null, null);

--- a/library/src/main/java/com/android/mms/transaction/NotificationTransaction.java
+++ b/library/src/main/java/com/android/mms/transaction/NotificationTransaction.java
@@ -40,6 +40,7 @@ import com.google.android.mms.pdu_alt.PduComposer;
 import com.google.android.mms.pdu_alt.PduHeaders;
 import com.google.android.mms.pdu_alt.PduParser;
 import com.google.android.mms.pdu_alt.PduPersister;
+import com.google.android.mms.pdu_alt.RetrieveConf;
 import com.klinker.android.logger.Log;
 import com.klinker.android.send_message.BroadcastUtils;
 
@@ -197,8 +198,11 @@ public class NotificationTransaction extends Transaction implements Runnable {
                             com.klinker.android.send_message.Transaction.settings.getGroup(), null);
 
                     // Use local time instead of PDU time
-                    ContentValues values = new ContentValues(1);
+                    ContentValues values = new ContentValues(2);
                     values.put(Mms.DATE, System.currentTimeMillis() / 1000L);
+                    // Store PDU time as sent time for received message
+                    RetrieveConf retrieveConf = (RetrieveConf) pdu;
+                    values.put(Mms.DATE_SENT, retrieveConf.getDate());
                     SqliteWrapper.update(mContext, mContext.getContentResolver(),
                             uri, values, null, null);
 

--- a/library/src/main/java/com/android/mms/transaction/RetrieveTransaction.java
+++ b/library/src/main/java/com/android/mms/transaction/RetrieveTransaction.java
@@ -168,8 +168,10 @@ public class RetrieveTransaction extends Transaction implements Runnable {
                             group, null);
 
                     // Use local time instead of PDU time
-                    ContentValues values = new ContentValues(2);
+                    ContentValues values = new ContentValues(3);
                     values.put(Mms.DATE, System.currentTimeMillis() / 1000L);
+                    // Store PDU time as sent time for received message
+                    values.put(Mms.DATE_SENT, retrieveConf.getDate());
                     values.put(Mms.MESSAGE_SIZE, resp.length);
                     SqliteWrapper.update(mContext, mContext.getContentResolver(),
                             msgUri, values, null, null);


### PR DESCRIPTION
I would like to obtain the date that received MMS message has sent.

Currently, date of MMS message is not set from PDU but system clock on received device.
This is because of causing the problem when timezones weren't set correctly.
*ref: aosp-mirror/platform_packages_apps_mms@69481af

However that's not a problem on using on same region, so please store the original PDU time to additional column (`Telephony.MMS.DATE_SENT`) to obtain from client app easier.
As far as I know the column is not used for received messages.

Thanks.
