### PR TITLE
Use right SMSManager object based on subscription id for downloading MMS

### DIFF
--- a/library/src/main/java/com/android/mms/transaction/DownloadManager.java
+++ b/library/src/main/java/com/android/mms/transaction/DownloadManager.java
@@ -21,6 +21,7 @@ import com.android.mms.MmsConfig;
 import com.klinker.android.logger.Log;
 import com.klinker.android.send_message.BroadcastUtils;
 import com.klinker.android.send_message.MmsReceivedReceiver;
+import com.klinker.android.send_message.SmsManagerFactory;
 
 import java.io.File;
 import java.util.Random;
@@ -44,7 +45,7 @@ public class DownloadManager {
 
     }
 
-    public void downloadMultimediaMessage(final Context context, final String location, Uri uri, boolean byPush) {
+    public void downloadMultimediaMessage(final Context context, final String location, Uri uri, boolean byPush, int subscriptionId) {
         if (location == null || mMap.get(location) != null) {
             return;
         }
@@ -83,7 +84,7 @@ public class DownloadManager {
         }
 
         grantUriPermission(context, contentUri);
-        SmsManager.getDefault().downloadMultimediaMessage(context,
+        SmsManagerFactory.createSmsManager(subscriptionId).downloadMultimediaMessage(context,
                 location, contentUri, configOverrides, pendingIntent);
     }
 

--- a/library/src/main/java/com/android/mms/transaction/PushReceiver.java
+++ b/library/src/main/java/com/android/mms/transaction/PushReceiver.java
@@ -28,13 +28,12 @@ import android.database.sqlite.SqliteWrapper;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
-import android.os.PowerManager;
 import android.preference.PreferenceManager;
 import android.provider.Telephony.Mms;
 import android.provider.Telephony.Mms.Inbox;
 
-import com.android.mms.logs.LogTag;
 import com.android.mms.MmsConfig;
+import com.android.mms.logs.LogTag;
 import com.android.mms.service_alt.DownloadRequest;
 import com.android.mms.service_alt.MmsNetworkManager;
 import com.android.mms.service_alt.MmsRequestManager;
@@ -49,6 +48,7 @@ import com.google.android.mms.pdu_alt.PduPersister;
 import com.google.android.mms.pdu_alt.ReadOrigInd;
 import com.klinker.android.logger.Log;
 import com.klinker.android.send_message.BroadcastUtils;
+import com.klinker.android.send_message.Settings;
 import com.klinker.android.send_message.Utils;
 
 import java.util.HashSet;
@@ -192,7 +192,8 @@ public class PushReceiver extends BroadcastReceiver {
                                 }
 
                                 if (useSystem) {
-                                    DownloadManager.getInstance().downloadMultimediaMessage(mContext, location, uri, true);
+                                    int subId = intent.getIntExtra("subscription", Settings.DEFAULT_SUBSCRIPTION_ID);
+                                    DownloadManager.getInstance().downloadMultimediaMessage(mContext, location, uri, true, subId);
                                 } else {
                                     Log.v(TAG, "receiving with lollipop method");
                                     MmsRequestManager requestManager = new MmsRequestManager(mContext);

--- a/library/src/main/java/com/android/mms/transaction/TransactionService.java
+++ b/library/src/main/java/com/android/mms/transaction/TransactionService.java
@@ -57,6 +57,7 @@ import com.google.android.mms.pdu_alt.PduPersister;
 import com.klinker.android.logger.Log;
 import com.klinker.android.send_message.BroadcastUtils;
 import com.klinker.android.send_message.R;
+import com.klinker.android.send_message.Settings;
 import com.klinker.android.send_message.Utils;
 
 import java.io.IOException;
@@ -317,9 +318,11 @@ public class TransactionService extends Service implements Observer {
 
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                             boolean useSystem = true;
+                            int subId = Settings.DEFAULT_SUBSCRIPTION_ID;
                             if (com.klinker.android.send_message.Transaction.settings != null) {
                                 useSystem = com.klinker.android.send_message.Transaction.settings
                                         .getUseSystemSending();
+                                subId = com.klinker.android.send_message.Transaction.settings.getSubscriptionId();
                             } else {
                                 useSystem = PreferenceManager.getDefaultSharedPreferences(this)
                                         .getBoolean("system_mms_sending", useSystem);
@@ -330,7 +333,7 @@ public class TransactionService extends Service implements Observer {
                                     Uri uri = ContentUris.withAppendedId(Mms.CONTENT_URI,
                                             cursor.getLong(columnIndexOfMsgId));
                                     com.android.mms.transaction.DownloadManager.getInstance().
-                                            downloadMultimediaMessage(this, PushReceiver.getContentLocation(this, uri), uri, false);
+                                            downloadMultimediaMessage(this, PushReceiver.getContentLocation(this, uri), uri, false, subId);
 
                                     // can't handle many messages at once.
                                     break;
@@ -857,7 +860,7 @@ public class TransactionService extends Service implements Observer {
                                     Uri u = Uri.parse(args.getUri());
                                     com.android.mms.transaction.DownloadManager.getInstance().
                                             downloadMultimediaMessage(TransactionService.this,
-                                                    ((RetrieveTransaction) transaction).getContentLocation(TransactionService.this, u), u, false);
+                                                    ((RetrieveTransaction) transaction).getContentLocation(TransactionService.this, u), u, false, Settings.DEFAULT_SUBSCRIPTION_ID);
                                     return;
                                 }
 


### PR DESCRIPTION
Downloading MMS in dual SIM cases may fail.
Example: User has two SIMs with subscription ids 1 & 2 say.
Current library always try to use default SMSManager for downloading MMS, which might fail if default subscription used is say 1 but actual MMS is received on 2.
I tested on Pulse SMS app, issue exist on Pulse SMS app as well.

Fix is to use SMS Manager based on subscription id of the received MMS, if id does not exist we fallback to using default. 