### PR TITLE
Fix subscription id info saved in OS db in dual SIM scenarios when MMS is sent or received

### DIFF
--- a/library/src/main/java/com/android/mms/service_alt/DownloadRequest.java
+++ b/library/src/main/java/com/android/mms/service_alt/DownloadRequest.java
@@ -174,7 +174,8 @@ public class DownloadRequest extends MmsRequest {
                     Telephony.Mms.Inbox.CONTENT_URI,
                     true/*createThreadId*/,
                     true/*groupMmsEnabled*/,
-                    null/*preOpenedFiles*/);
+                    null/*preOpenedFiles*/,
+                    subId);
             if (messageUri == null) {
                 Log.e(TAG, "DownloadRequest.persistIfRequired: can not persist message");
                 return null;

--- a/library/src/main/java/com/android/mms/service_alt/MmsRequestManager.java
+++ b/library/src/main/java/com/android/mms/service_alt/MmsRequestManager.java
@@ -29,6 +29,7 @@ import com.google.android.mms.pdu_alt.PduParser;
 import com.google.android.mms.pdu_alt.PduPersister;
 import com.google.android.mms.pdu_alt.RetrieveConf;
 import com.google.android.mms.util_alt.SqliteWrapper;
+import com.klinker.android.send_message.Settings;
 
 public class MmsRequestManager implements MmsRequest.RequestManager {
 
@@ -76,9 +77,11 @@ public class MmsRequestManager implements MmsRequest.RequestManager {
 
             Uri msgUri;
             boolean group;
+            int subId = Settings.DEFAULT_SUBSCRIPTION_ID;
 
             try {
                 group = com.klinker.android.send_message.Transaction.settings.getGroup();
+                subId = com.klinker.android.send_message.Transaction.settings.getSubscriptionId();
             } catch (Exception e) {
                 group = PreferenceManager.getDefaultSharedPreferences(context).getBoolean("group_message", true);
             }
@@ -86,7 +89,7 @@ public class MmsRequestManager implements MmsRequest.RequestManager {
             // Store M-Retrieve.conf into Inbox
             PduPersister persister = PduPersister.getPduPersister(context);
             msgUri = persister.persist(retrieveConf, Telephony.Mms.Inbox.CONTENT_URI, true,
-                    group, null);
+                    group, null, subId);
 
             // Use local time instead of PDU time
             ContentValues values = new ContentValues(3);

--- a/library/src/main/java/com/android/mms/service_alt/SubscriptionIdChecker.java
+++ b/library/src/main/java/com/android/mms/service_alt/SubscriptionIdChecker.java
@@ -10,7 +10,7 @@ import android.util.Log;
 
 import com.google.android.mms.util_alt.SqliteWrapper;
 
-class SubscriptionIdChecker {
+public class SubscriptionIdChecker {
     private static final String TAG = "SubscriptionIdChecker";
 
     private static SubscriptionIdChecker sInstance;
@@ -37,7 +37,7 @@ class SubscriptionIdChecker {
         }
     }
 
-    static synchronized SubscriptionIdChecker getInstance(Context context) {
+    public static synchronized SubscriptionIdChecker getInstance(Context context) {
         if (sInstance == null) {
             sInstance = new SubscriptionIdChecker();
             sInstance.check(context);
@@ -45,7 +45,7 @@ class SubscriptionIdChecker {
         return sInstance;
     }
 
-    boolean canUseSubscriptionId() {
+    public boolean canUseSubscriptionId() {
         return mCanUseSubscriptionId;
     }
 }

--- a/library/src/main/java/com/android/mms/transaction/DownloadManager.java
+++ b/library/src/main/java/com/android/mms/transaction/DownloadManager.java
@@ -74,6 +74,7 @@ public class DownloadManager {
         download.putExtra(MmsReceivedReceiver.EXTRA_LOCATION_URL, location);
         download.putExtra(MmsReceivedReceiver.EXTRA_TRIGGER_PUSH, byPush);
         download.putExtra(MmsReceivedReceiver.EXTRA_URI, uri);
+        download.putExtra(MmsReceivedReceiver.SUBSCRIPTION_ID, subscriptionId);
         final PendingIntent pendingIntent = PendingIntent.getBroadcast(
                 context, 0, download, PendingIntent.FLAG_CANCEL_CURRENT);
 

--- a/library/src/main/java/com/android/mms/transaction/MmsMessageSender.java
+++ b/library/src/main/java/com/android/mms/transaction/MmsMessageSender.java
@@ -39,6 +39,7 @@ import com.google.android.mms.pdu_alt.PduPersister;
 import com.google.android.mms.pdu_alt.ReadRecInd;
 import com.google.android.mms.pdu_alt.SendReq;
 import com.google.android.mms.util_alt.SqliteWrapper;
+import com.klinker.android.send_message.Settings;
 
 public class MmsMessageSender implements MessageSender {
     private static final String TAG = LogTag.TAG;
@@ -168,14 +169,16 @@ public class MmsMessageSender implements MessageSender {
             readRec.setDate(System.currentTimeMillis() / 1000);
 
             boolean group;
+            int subId = Settings.DEFAULT_SUBSCRIPTION_ID;
 
             try {
                 group = com.klinker.android.send_message.Transaction.settings.getGroup();
+                subId = com.klinker.android.send_message.Transaction.settings.getSubscriptionId();
             } catch (Exception e) {
                 group = PreferenceManager.getDefaultSharedPreferences(context).getBoolean("group_message", true);
             }
             PduPersister.getPduPersister(context).persist(readRec, Mms.Outbox.CONTENT_URI, true,
-                    group, null);
+                    group, null, subId);
             context.startService(new Intent(context, TransactionService.class));
         } catch (InvalidHeaderValueException e) {
             Log.e(TAG, "Invalide header value", e);

--- a/library/src/main/java/com/android/mms/transaction/NotificationTransaction.java
+++ b/library/src/main/java/com/android/mms/transaction/NotificationTransaction.java
@@ -43,6 +43,7 @@ import com.google.android.mms.pdu_alt.PduPersister;
 import com.google.android.mms.pdu_alt.RetrieveConf;
 import com.klinker.android.logger.Log;
 import com.klinker.android.send_message.BroadcastUtils;
+import com.klinker.android.send_message.Settings;
 
 import java.io.IOException;
 
@@ -113,15 +114,17 @@ public class NotificationTransaction extends Transaction implements Runnable {
             // Save the pdu. If we can start downloading the real pdu immediately, don't allow
             // persist() to create a thread for the notificationInd because it causes UI jank.
             boolean group;
+            int subId = Settings.DEFAULT_SUBSCRIPTION_ID;
 
             try {
                 group = com.klinker.android.send_message.Transaction.settings.getGroup();
+                subId = com.klinker.android.send_message.Transaction.settings.getSubscriptionId();
             } catch (Exception e) {
                 group = PreferenceManager.getDefaultSharedPreferences(context).getBoolean("group_message", true);
             }
             mUri = PduPersister.getPduPersister(context).persist(
                         ind, Inbox.CONTENT_URI, !allowAutoDownload(mContext),
-                        group, null);
+                        group, null, subId);
         } catch (MmsException e) {
             Log.e(TAG, "Failed to save NotificationInd in constructor.", e);
             throw new IllegalArgumentException();
@@ -195,7 +198,7 @@ public class NotificationTransaction extends Transaction implements Runnable {
                     // Save the received PDU (must be a M-RETRIEVE.CONF).
                     PduPersister p = PduPersister.getPduPersister(mContext);
                     Uri uri = p.persist(pdu, Inbox.CONTENT_URI, true,
-                            com.klinker.android.send_message.Transaction.settings.getGroup(), null);
+                            com.klinker.android.send_message.Transaction.settings.getGroup(), null, com.klinker.android.send_message.Transaction.settings.getSubscriptionId());
 
                     // Use local time instead of PDU time
                     ContentValues values = new ContentValues(2);

--- a/library/src/main/java/com/android/mms/transaction/PushReceiver.java
+++ b/library/src/main/java/com/android/mms/transaction/PushReceiver.java
@@ -147,7 +147,6 @@ public class PushReceiver extends BroadcastReceiver {
 
                         boolean appendTransactionId = false;
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                            int subId = intent.getIntExtra("subscription", Settings.DEFAULT_SUBSCRIPTION_ID);
                             Bundle configOverrides = SmsManagerFactory.createSmsManager(subId).getCarrierConfigValues();
                             appendTransactionId = configOverrides.getBoolean(SmsManager.MMS_CONFIG_APPEND_TRANSACTION_ID);
 

--- a/library/src/main/java/com/android/mms/transaction/PushReceiver.java
+++ b/library/src/main/java/com/android/mms/transaction/PushReceiver.java
@@ -113,6 +113,7 @@ public class PushReceiver extends BroadcastReceiver {
             ContentResolver cr = mContext.getContentResolver();
             int type = pdu.getMessageType();
             long threadId = -1;
+            int subId = intent.getIntExtra("subscription", Settings.DEFAULT_SUBSCRIPTION_ID);
 
             try {
                 switch (type) {
@@ -134,7 +135,7 @@ public class PushReceiver extends BroadcastReceiver {
                         }
 
                         Uri uri = p.persist(pdu, Uri.parse("content://mms/inbox"), true,
-                                group, null);
+                                group, null, subId);
                         // Update thread ID for ReadOrigInd & DeliveryInd.
                         ContentValues values = new ContentValues(1);
                         values.put(Mms.THREAD_ID, threadId);
@@ -184,7 +185,8 @@ public class PushReceiver extends BroadcastReceiver {
                             Uri uri = p.persist(pdu, Inbox.CONTENT_URI,
                                     !NotificationTransaction.allowAutoDownload(mContext),
                                     group,
-                                    null);
+                                    null,
+                                    subId);
 
                             String location;
                             try {
@@ -216,7 +218,6 @@ public class PushReceiver extends BroadcastReceiver {
                                 }
 
                                 if (useSystem) {
-                                    int subId = intent.getIntExtra("subscription", Settings.DEFAULT_SUBSCRIPTION_ID);
                                     DownloadManager.getInstance().downloadMultimediaMessage(mContext, location, uri, true, subId);
                                 } else {
                                     Log.v(TAG, "receiving with lollipop method");

--- a/library/src/main/java/com/android/mms/transaction/RetrieveTransaction.java
+++ b/library/src/main/java/com/android/mms/transaction/RetrieveTransaction.java
@@ -40,6 +40,7 @@ import com.google.android.mms.pdu_alt.PduHeaders;
 import com.google.android.mms.pdu_alt.PduParser;
 import com.google.android.mms.pdu_alt.PduPersister;
 import com.google.android.mms.pdu_alt.RetrieveConf;
+import com.klinker.android.send_message.Settings;
 import com.klinker.android.send_message.Utils;
 
 /**
@@ -155,9 +156,11 @@ public class RetrieveTransaction extends Transaction implements Runnable {
                     mTransactionState.setContentUri(mUri);
                 } else {
                     boolean group;
+                    int subId = Settings.DEFAULT_SUBSCRIPTION_ID;
 
                     try {
                         group = com.klinker.android.send_message.Transaction.settings.getGroup();
+                        subId = com.klinker.android.send_message.Transaction.settings.getSubscriptionId();
                     } catch (Exception e) {
                         group = PreferenceManager.getDefaultSharedPreferences(mContext).getBoolean("group_message", true);
                     }
@@ -165,7 +168,7 @@ public class RetrieveTransaction extends Transaction implements Runnable {
                     // Store M-Retrieve.conf into Inbox
                     PduPersister persister = PduPersister.getPduPersister(mContext);
                     msgUri = persister.persist(retrieveConf, Inbox.CONTENT_URI, true,
-                            group, null);
+                            group, null, subId);
 
                     // Use local time instead of PDU time
                     ContentValues values = new ContentValues(3);

--- a/library/src/main/java/com/google/android/mms/pdu_alt/PduPersister.java
+++ b/library/src/main/java/com/google/android/mms/pdu_alt/PduPersister.java
@@ -29,6 +29,7 @@ import android.drm.DrmManagerClient;
 import android.net.Uri;
 import android.os.Build;
 import android.provider.MediaStore;
+import android.provider.Telephony;
 import android.provider.Telephony.Mms;
 import android.provider.Telephony.Mms.Addr;
 import android.provider.Telephony.Mms.Part;
@@ -39,6 +40,7 @@ import android.telephony.PhoneNumberUtils;
 import android.telephony.TelephonyManager;
 import android.text.TextUtils;
 
+import com.android.mms.service_alt.SubscriptionIdChecker;
 import com.google.android.mms.ContentType;
 import com.google.android.mms.InvalidHeaderValueException;
 import com.google.android.mms.MmsException;
@@ -48,6 +50,7 @@ import com.google.android.mms.util_alt.PduCache;
 import com.google.android.mms.util_alt.PduCacheEntry;
 import com.google.android.mms.util_alt.SqliteWrapper;
 import com.klinker.android.logger.Log;
+import com.klinker.android.send_message.Settings;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -1278,7 +1281,7 @@ public class PduPersister {
      */
 
     public Uri persist(GenericPdu pdu, Uri uri, boolean createThreadId, boolean groupMmsEnabled,
-            HashMap<Uri, InputStream> preOpenedFiles)
+            HashMap<Uri, InputStream> preOpenedFiles, int subscriptionId)
             throws MmsException {
         if (uri == null) {
             throw new MmsException("Uri may not be null.");
@@ -1458,6 +1461,11 @@ public class PduPersister {
         // PDU header. If not, then we insert the message size as well.
         if (values.getAsInteger(Mms.MESSAGE_SIZE) == null) {
             values.put(Mms.MESSAGE_SIZE, messageSize);
+        }
+
+        // insert only if it is a valid subscription id.
+        if (Settings.DEFAULT_SUBSCRIPTION_ID != subscriptionId && SubscriptionIdChecker.getInstance(mContext).canUseSubscriptionId()) {
+            values.put(Telephony.Mms.SUBSCRIPTION_ID, subscriptionId);
         }
 
         Uri res = null;

--- a/library/src/main/java/com/klinker/android/send_message/MmsReceivedReceiver.java
+++ b/library/src/main/java/com/klinker/android/send_message/MmsReceivedReceiver.java
@@ -64,6 +64,7 @@ public abstract class MmsReceivedReceiver extends BroadcastReceiver {
     public static final String EXTRA_LOCATION_URL = "location_url";
     public static final String EXTRA_TRIGGER_PUSH = "trigger_push";
     public static final String EXTRA_URI = "notification_ind_uri";
+    public static final String SUBSCRIPTION_ID = "subscription_id";
 
     private static final String LOCATION_SELECTION =
             Telephony.Mms.MESSAGE_TYPE + "=? AND " + Telephony.Mms.CONTENT_LOCATION + " =?";
@@ -88,6 +89,7 @@ public abstract class MmsReceivedReceiver extends BroadcastReceiver {
         Log.v(TAG, "MMS has finished downloading, persisting it to the database");
 
         final String path = intent.getStringExtra(EXTRA_FILE_PATH);
+        final int subscriptionId = intent.getIntExtra(SUBSCRIPTION_ID, Utils.getDefaultSubscriptionId());
         Log.v(TAG, path);
 
         new Thread(new Runnable() {
@@ -109,7 +111,7 @@ public abstract class MmsReceivedReceiver extends BroadcastReceiver {
                     messageUri = DownloadRequest.persist(context, response,
                             new MmsConfig.Overridden(new MmsConfig(context), null),
                             intent.getStringExtra(EXTRA_LOCATION_URL),
-                            Utils.getDefaultSubscriptionId(), null);
+                            subscriptionId, null);
 
                     Log.v(TAG, "response saved successfully");
                     Log.v(TAG, "response length: " + response.length);

--- a/library/src/main/java/com/klinker/android/send_message/Transaction.java
+++ b/library/src/main/java/com/klinker/android/send_message/Transaction.java
@@ -614,7 +614,7 @@ public class Transaction {
         if (saveMessage) {
             try {
                 PduPersister persister = PduPersister.getPduPersister(context);
-                info.location = persister.persist(sendRequest, Uri.parse("content://mms/outbox"), true, settings.getGroup(), null);
+                info.location = persister.persist(sendRequest, Uri.parse("content://mms/outbox"), true, settings.getGroup(), null, settings.getSubscriptionId());
             } catch (Exception e) {
                 Log.v("sending_mms_library", "error saving mms message");
                 Log.e(TAG, "exception thrown", e);
@@ -656,7 +656,7 @@ public class Transaction {
                 // this will be the default behavior if we do not explicitly set the save flag to false
                 PduPersister persister = PduPersister.getPduPersister(context);
                 messageUri = persister.persist(sendReq, Uri.parse("content://mms/outbox"),
-                        true, settings.getGroup(), null);
+                        true, settings.getGroup(), null, settings.getSubscriptionId());
             } else {
                 messageUri = existingMessageUri;
                 Log.v(TAG, messageUri.toString());


### PR DESCRIPTION
In dual SIM scenarios we need to save right subscription id info based on the sim we received the message.
This PR has fix to save the right subscription info for received as well as sent MMS