### PR TITLE
Add FLAG_IMMUTABLE to PendingIntents to satisfy SDK 31+ requirements

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -10,7 +10,7 @@ android {
     compileSdkVersion 25
 
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 21
         targetSdkVersion 25
     }
 

--- a/library/src/main/java/com/klinker/android/send_message/Transaction.java
+++ b/library/src/main/java/com/klinker/android/send_message/Transaction.java
@@ -267,7 +267,7 @@ public class Transaction {
                 sentIntent.putExtra("message_uri", messageUri == null ? "" : messageUri.toString());
                 sentIntent.putExtra(SENT_SMS_BUNDLE, sentMessageParcelable);
                 PendingIntent sentPI = PendingIntent.getBroadcast(
-                        context, messageId, sentIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+                        context, messageId, sentIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
                 Intent deliveredIntent;
                 if (explicitDeliveredSmsReceiver == null) {
@@ -280,7 +280,7 @@ public class Transaction {
                 deliveredIntent.putExtra("message_uri", messageUri == null ? "" : messageUri.toString());
                 deliveredIntent.putExtra(DELIVERED_SMS_BUNDLE, deliveredParcelable);
                 PendingIntent deliveredPI = PendingIntent.getBroadcast(
-                        context, messageId, deliveredIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+                        context, messageId, deliveredIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
                 ArrayList<PendingIntent> sPI = new ArrayList<PendingIntent>();
                 ArrayList<PendingIntent> dPI = new ArrayList<PendingIntent>();
@@ -682,7 +682,7 @@ public class Transaction {
             intent.putExtra(MmsSentReceiver.EXTRA_CONTENT_URI, messageUri.toString());
             intent.putExtra(MmsSentReceiver.EXTRA_FILE_PATH, mSendFile.getPath());
             final PendingIntent pendingIntent = PendingIntent.getBroadcast(
-                    context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+                    context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
             Uri writerUri = (new Uri.Builder())
                     .authority(context.getPackageName() + ".MmsFileProvider")

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -14,7 +14,7 @@ android {
 
     defaultConfig {
         applicationId "com.klinker.android.send_message.sample"
-        minSdkVersion 14
+        minSdkVersion 21
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
As described in #187, post SDK 31, Android requires that any PendingIntent specify either FLAG_IMMUTABLE or FLAG_MUTABLE, with FLAG_MUTABLE being the default behavior prior to SDK 31.

This change moves relevant PendingIntents to FLAG_IMMUTABLE. This seems to be safe because the PendingIntents created by this library do not seem to require mutability.

FLAG_MUTABLE would require bumping all the way to SDK31; this is much more difficult because Android has hidden several methods of the ConnectivityManager class, such as startUsingNetworkFeature, for which there does not appear to be a drop-in replacement.

This has been tested in my use to send both SMS and MMS with attachment, where the app operates as not the default system messaging app. If the app were the default messaging app, FLAG_MUTABLE might be necessary (I do not know).