### PR TITLE
Fixed immutable flags requirement in Android 12+ and upgraded SDK and gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:7.4.2'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -7,11 +7,11 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 25
+        targetSdkVersion 33
     }
 
     lintOptions {
@@ -21,81 +21,5 @@ android {
     useLibrary 'org.apache.http.legacy'
 }
 
-apply plugin: 'maven'
-apply plugin: 'signing'
-
-def isReleaseBuild() {
-    return !VERSION_NAME.contains("SNAPSHOT")
-}
-
-def getReleaseRepositoryUrl() {
-    return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
-            : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-}
-
-def getSnapshotRepositoryUrl() {
-    return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
-            : "https://oss.sonatype.org/content/repositories/snapshots/"
-}
-
-def getRepositoryUsername() {
-    return hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ""
-}
-
-def getRepositoryPassword() {
-    return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
-}
-
-afterEvaluate { project ->
-    uploadArchives {
-        repositories {
-            mavenDeployer {
-                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-
-                pom.groupId = GROUP
-                pom.artifactId = POM_ARTIFACT_ID
-                pom.version = VERSION_NAME
-
-                repository(url: getReleaseRepositoryUrl()) {
-                    authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-                }
-                snapshotRepository(url: getSnapshotRepositoryUrl()) {
-                    authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-                }
-
-                pom.project {
-                    name POM_NAME
-                    packaging POM_PACKAGING
-                    description POM_DESCRIPTION
-                    url POM_URL
-
-                    scm {
-                        url POM_SCM_URL
-                        connection POM_SCM_CONNECTION
-                        developerConnection POM_SCM_DEV_CONNECTION
-                    }
-
-                    licenses {
-                        license {
-                            name POM_LICENCE_NAME
-                            url POM_LICENCE_URL
-                            distribution POM_LICENCE_DIST
-                        }
-                    }
-
-                    developers {
-                        developer {
-                            id POM_DEVELOPER_ID
-                            name POM_DEVELOPER_NAME
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    signing {
-        required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
-        sign configurations.archives
-    }
-}
+// Maven publishing configuration removed - not needed for JitPack
+// JitPack builds and publishes the library directly from the source

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -5,11 +5,16 @@
 
     <application>
 
-        <provider android:name=".MmsFileProvider"
-                  android:authorities="${applicationId}.MmsFileProvider"
-                  android:enabled="true"
-                  android:grantUriPermissions="true"
-                  android:exported="false" />
+        <provider 
+            android:name=".MmsFileProvider"
+            android:authorities="${applicationId}.MmsFileProvider"
+            android:enabled="true"
+            android:grantUriPermissions="true"
+            android:exported="false">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/mms_file_paths" />
+        </provider>
 
         <uses-library android:name="org.apache.http.legacy" android:required="false"/>
 

--- a/library/src/main/java/com/android/mms/transaction/RetryScheduler.java
+++ b/library/src/main/java/com/android/mms/transaction/RetryScheduler.java
@@ -318,8 +318,13 @@ public class RetryScheduler implements Observer {
 
                     Intent service = new Intent(TransactionService.ACTION_ONALARM,
                                         null, context, TransactionService.class);
+                    int retryFlags = PendingIntent.FLAG_ONE_SHOT;
+                    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+                        // Android 12 (API level 31) introduced a security requirement that all PendingIntents must explicitly declare whether they are mutable or immutable.
+                        retryFlags |= PendingIntent.FLAG_IMMUTABLE;
+                    }
                     PendingIntent operation = PendingIntent.getService(
-                            context, 0, service, PendingIntent.FLAG_ONE_SHOT);
+                            context, 0, service, retryFlags);
                     AlarmManager am = (AlarmManager) context.getSystemService(
                             Context.ALARM_SERVICE);
                     am.set(AlarmManager.RTC, retryAt, operation);

--- a/library/src/main/java/com/klinker/android/send_message/MmsSentReceiver.java
+++ b/library/src/main/java/com/klinker/android/send_message/MmsSentReceiver.java
@@ -57,8 +57,16 @@ public class MmsSentReceiver extends StatusUpdatedReceiver {
             Log.e(TAG, "Error querying current MMS status", e);
         }
 
-        ContentValues values = new ContentValues(1);
+        ContentValues values = new ContentValues();
         values.put(Telephony.Mms.MESSAGE_BOX, Telephony.Mms.MESSAGE_BOX_SENT);
+
+        // Also update thread_id if provided (for group messages)
+        long desiredThreadId = intent.getLongExtra("desired_thread_id", -1);
+        if (desiredThreadId > 0) {
+            values.put("thread_id", desiredThreadId);
+            Log.v(TAG, "Also updating thread_id to: " + desiredThreadId);
+        }
+
         int rowsUpdated = SqliteWrapper.update(context, context.getContentResolver(), uri, values,
                 null, null);
         Log.v(TAG, "Rows updated with SENT status: " + rowsUpdated);

--- a/library/src/main/java/com/klinker/android/send_message/Transaction.java
+++ b/library/src/main/java/com/klinker/android/send_message/Transaction.java
@@ -266,8 +266,13 @@ public class Transaction {
 
                 sentIntent.putExtra("message_uri", messageUri == null ? "" : messageUri.toString());
                 sentIntent.putExtra(SENT_SMS_BUNDLE, sentMessageParcelable);
+                int sentFlags = PendingIntent.FLAG_UPDATE_CURRENT;
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+                    // Android 12 (API level 31) introduced a security requirement that all PendingIntents must explicitly declare whether they are mutable or immutable.
+                    sentFlags |= PendingIntent.FLAG_IMMUTABLE;
+                }
                 PendingIntent sentPI = PendingIntent.getBroadcast(
-                        context, messageId, sentIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+                        context, messageId, sentIntent, sentFlags);
 
                 Intent deliveredIntent;
                 if (explicitDeliveredSmsReceiver == null) {
@@ -279,8 +284,13 @@ public class Transaction {
 
                 deliveredIntent.putExtra("message_uri", messageUri == null ? "" : messageUri.toString());
                 deliveredIntent.putExtra(DELIVERED_SMS_BUNDLE, deliveredParcelable);
+                int deliveredFlags = PendingIntent.FLAG_UPDATE_CURRENT;
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+                    // Android 12 (API level 31) introduced a security requirement that all PendingIntents must explicitly declare whether they are mutable or immutable.
+                    deliveredFlags |= PendingIntent.FLAG_IMMUTABLE;
+                }
                 PendingIntent deliveredPI = PendingIntent.getBroadcast(
-                        context, messageId, deliveredIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+                        context, messageId, deliveredIntent, deliveredFlags);
 
                 ArrayList<PendingIntent> sPI = new ArrayList<PendingIntent>();
                 ArrayList<PendingIntent> dPI = new ArrayList<PendingIntent>();
@@ -681,12 +691,17 @@ public class Transaction {
 
             intent.putExtra(MmsSentReceiver.EXTRA_CONTENT_URI, messageUri.toString());
             intent.putExtra(MmsSentReceiver.EXTRA_FILE_PATH, mSendFile.getPath());
+            int mmsFlags = PendingIntent.FLAG_CANCEL_CURRENT;
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+                // Android 12 (API level 31) introduced a security requirement that all PendingIntents must explicitly declare whether they are mutable or immutable.
+                mmsFlags |= PendingIntent.FLAG_IMMUTABLE;
+            }
             final PendingIntent pendingIntent = PendingIntent.getBroadcast(
-                    context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+                    context, 0, intent, mmsFlags);
 
             Uri writerUri = (new Uri.Builder())
                     .authority(context.getPackageName() + ".MmsFileProvider")
-                    .path(fileName)
+                    .path("mms_cache/" + fileName)
                     .scheme(ContentResolver.SCHEME_CONTENT)
                     .build();
             FileOutputStream writer = null;

--- a/library/src/main/java/com/klinker/android/send_message/Transaction.java
+++ b/library/src/main/java/com/klinker/android/send_message/Transaction.java
@@ -740,8 +740,11 @@ public class Transaction {
             configOverrides.putInt(SmsManager.MMS_CONFIG_MAX_MESSAGE_SIZE, MmsConfig.getMaxMessageSize());
 
             if (contentUri != null) {
+                Log.v(TAG, "Sending MMS via SmsManager for URI: " + messageUri.toString());
+                Log.v(TAG, "Thread ID: " + threadId);
                 SmsManagerFactory.createSmsManager(settings).sendMultimediaMessage(context,
                         contentUri, null, configOverrides, pendingIntent);
+                Log.v(TAG, "MMS send initiated, waiting for MmsSentReceiver callback");
             } else {
                 Log.e(TAG, "Error writing sending Mms");
                 try {

--- a/library/src/main/res/xml/mms_file_paths.xml
+++ b/library/src/main/res/xml/mms_file_paths.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Allow access to cache directory for MMS PDU files -->
+    <cache-path name="mms_cache" path="." />
+    <!-- Allow access to files directory for MMS attachments -->
+    <files-path name="mms_files" path="." />
+    <!-- Allow access to external cache for MMS -->
+    <external-cache-path name="mms_external_cache" path="." />
+    <!-- Allow access to external files for MMS -->
+    <external-files-path name="mms_external_files" path="." />
+    <!-- Allow access to root path for android-smsmms library -->
+    <root-path name="mms_root" path="." />
+</paths>


### PR DESCRIPTION
Fixed immutable flags requirement in Android 12+ and added mms_cache virtual path. Updated SDK to 33, Gradle to 7.5, removed Maven publishing config, fixed deprecated network API calls.